### PR TITLE
Comment out today specification

### DIFF
--- a/api-docs/conf.py
+++ b/api-docs/conf.py
@@ -79,7 +79,7 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-today = 'December 8, 2015'
+#today = 'December 8, 2015'
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 


### PR DESCRIPTION
Current Sphinx version (1.3.2) includes a default "today" variable that inserts the current date in   month-name, day, year format  (December 8, 2015).  No need to include specification in conf.py.