### PR TITLE
Numerous updates & additions including ns docs, typos, missing values, formatting

### DIFF
--- a/api-docs/v2/api-operations/methods/DELETE_deleteRecordset_v2__account_id__zones__zone_id__recordsets__recordset_id__recordsets.rst
+++ b/api-docs/v2/api-operations/methods/DELETE_deleteRecordset_v2__account_id__zones__zone_id__recordsets__recordset_id__recordsets.rst
@@ -81,8 +81,8 @@ set id request:
 
 .. code::  
 
-    DELETE /v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648 HTTP/1.1
-    Host: 127.0.0.1:9001
+    DELETE /v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 

--- a/api-docs/v2/api-operations/methods/DELETE_deleteZoneExport_v2__account_id__zones_tasks_exports__uuid_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/DELETE_deleteZoneExport_v2__account_id__zones_tasks_exports__uuid_id__zones.rst
@@ -46,8 +46,8 @@ This table shows the URI parameters for the delete a zone export request:
 
 .. code::  
 
-    DELETE /v2/zones/tasks/exports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
-    Host: 127.0.0.1:9001
+    DELETE /v2/123456/zones/tasks/exports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 

--- a/api-docs/v2/api-operations/methods/DELETE_deleteZoneImport_v2__account_id__zones_tasks_imports__zone_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/DELETE_deleteZoneImport_v2__account_id__zones_tasks_imports__zone_id__zones.rst
@@ -46,8 +46,8 @@ This table shows the URI parameters for the delete a zone import request:
 
 .. code::  
 
-    DELETE /v2/1234/zones/tasks/imports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
-    Host: 127.0.0.1:9001
+    DELETE /v2/123456/zones/tasks/imports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 

--- a/api-docs/v2/api-operations/methods/DELETE_deleteZone_v2__account_id__zones__zone_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/DELETE_deleteZone_v2__account_id__zones__zone_id__zones.rst
@@ -84,8 +84,8 @@ This table shows the URI parameters for the delete zone request:
 
 .. code::  
 
-    DELETE /v2/1234/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
-    Host: 127.0.0.1:9001
+    DELETE /v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 

--- a/api-docs/v2/api-operations/methods/GET_listExportedZone_v2__account_id__zones_tasks_exports__uuid_id__export_zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listExportedZone_v2__account_id__zones_tasks_exports__uuid_id__export_zones.rst
@@ -47,7 +47,7 @@ This table shows the URI parameters for the list exported zone request:
 .. code::  
 
     GET /zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720/export HTTP/1.1
-    Host: 127.0.0.1:9001
+    Host: global.dns.rackspacecloud.com
     Accept: text/dns
 
 This operation does not accept a request body.

--- a/api-docs/v2/api-operations/methods/GET_listRecordset_v2__account_id__zones__zone_id__recordsets__recordset_id__recordsets.rst
+++ b/api-docs/v2/api-operations/methods/GET_listRecordset_v2__account_id__zones__zone_id__recordsets__recordset_id__recordsets.rst
@@ -78,8 +78,8 @@ This table shows the URI parameters for the list record set request:
 
 .. code::  
 
-    GET /v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648 HTTP/1.1
-    Host: 127.0.0.1:9001
+    GET /v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -96,7 +96,7 @@ This operation does not accept a request body.
     {
         "description": "This is an example recordset.",
         "links": {
-            "self": "https://127.0.0.1:9001/v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
         },
         "updated_at": null,
         "records": [

--- a/api-docs/v2/api-operations/methods/GET_listRecordsets_v2__account_id__zones__zone_id__recordsets_recordsets.rst
+++ b/api-docs/v2/api-operations/methods/GET_listRecordsets_v2__account_id__zones__zone_id__recordsets_recordsets.rst
@@ -67,8 +67,8 @@ This table shows the URI parameters for the list all record sets for a specified
 
 .. code::  
 
-    GET /v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
-    Host: 127.0.0.1:9001
+    GET /v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -89,7 +89,7 @@ This operation does not accept a request body.
             {
                 "description": null,
                 "links": {
-                    "self": "https://127.0.0.1:9001/v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/65ee6b49-bb4c-4e52-9799-31330c94161f"
+                    "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/65ee6b49-bb4c-4e52-9799-31330c94161f"
                 },
                 "updated_at": null,
                 "records": [
@@ -106,7 +106,7 @@ This operation does not accept a request body.
             {
                 "description": null,
                 "links": {
-                    "self": "https://127.0.0.1:9001/v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/14500cf9-bdff-48f6-b06b-5fc7491ffd9e"
+                    "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/14500cf9-bdff-48f6-b06b-5fc7491ffd9e"
                 },
                 "updated_at": "2014-10-24T19:59:46.000000",
                 "records": [
@@ -123,7 +123,7 @@ This operation does not accept a request body.
             {
                 "description": "This is an example recordset.",
                 "links": {
-                    "self": "https://127.0.0.1:9001/v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+                    "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
                 },
                 "updated_at": null,
                 "records": [
@@ -139,7 +139,7 @@ This operation does not accept a request body.
             }
         ],
         "links": {
-            "self": "https://127.0.0.1:9001/v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets"
+            "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets"
         },
         "metadata": {
             "total_count": 3

--- a/api-docs/v2/api-operations/methods/GET_listZoneExport_v2__account_id__zones_tasks_exports__uuid_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneExport_v2__account_id__zones_tasks_exports__uuid_id__zones.rst
@@ -45,8 +45,8 @@ request:
 
 .. code::  
 
-    GET /v2/zones/tasks/exports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
-    Host: 127.0.0.1:9001
+    GET /v2/123456/zones/tasks/exports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
 
 This operation does not accept a request body.
@@ -62,13 +62,13 @@ This operation does not accept a request body.
         "status": "COMPLETE",
         "zone_id": "6625198b-d67d-47dc-8d29-f90bd60f3ac4",
         "links": {
-            "self": "http://127.0.0.1:9001/v2/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720",
-            "export": "http://127.0.0.1:9001/v2/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720/export"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720",
+            "export": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720/export"
         },
         "created_at": "2015-08-27T20:57:03.000000",
         "updated_at": "2015-08-27T20:57:03.000000",
         "version": 2,
-        "location": "designate://v2/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720/export",
+        "location": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720/export",
         "message": null,
         "project_id": "noauth-project",
         "id": "8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720"

--- a/api-docs/v2/api-operations/methods/GET_listZoneExports_v2__account_id__zones_tasks_exports_zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneExports_v2__account_id__zones_tasks_exports_zones.rst
@@ -42,8 +42,8 @@ This table shows the URI parameters for the list zone exports request:
 
 .. code::  
 
-    GET /v2/1234/zones/tasks/exports/ HTTP/1.1
-    Host: 127.0.0.1:9001
+    GET /v2/123456/zones/tasks/exports/ HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
 
 This operation does not accept a request body.
@@ -61,13 +61,13 @@ This operation does not accept a request body.
                 "status": "COMPLETE",
                 "zone_id": "30ea7692-7f9e-4195-889e-0ba11620b491",
                 "links": {
-                    "self": "http://127.0.0.1:9001/v2/zones/tasks/exports/d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248",
-                    "export": "http://127.0.0.1:9001/v2/zones/30ea7692-7f9e-4195-889e-0ba11620b491/tasks/exports/d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248/export"
+                    "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248",
+                    "export": "https://global.dns.rackspacecloud.com/v2/123456/zones/30ea7692-7f9e-4195-889e-0ba11620b491/tasks/exports/d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248/export"
                 },
                 "created_at": "2015-08-24T19:46:50.000000",
                 "updated_at": "2015-08-24T19:46:50.000000",
                 "version": 2,
-                "location": "designate://v2/zones/30ea7692-7f9e-4195-889e-0ba11620b491/tasks/exports/d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248/export",
+                "location": "https://global.dns.rackspacecloud.com/v2/123456/zones/30ea7692-7f9e-4195-889e-0ba11620b491/tasks/exports/d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248/export",
                 "message": null,
                 "project_id": "noauth-project",
                 "id": "d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248"
@@ -76,20 +76,20 @@ This operation does not accept a request body.
                 "status": "COMPLETE",
                 "zone_id": "0503f9fd-3938-47a4-bbf3-df99b088abfc",
                 "links": {
-                    "self": "http://127.0.0.1:9001/v2/zones/tasks/exports/3d7d07a5-2ce3-458e-b3dd-6a29906234d8",
-                    "export": "http://127.0.0.1:9001/v2/zones/tasks/exports/3d7d07a5-2ce3-458e-b3dd-6a29906234d8/export"
+                    "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/3d7d07a5-2ce3-458e-b3dd-6a29906234d8",
+                    "export": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/3d7d07a5-2ce3-458e-b3dd-6a29906234d8/export"
                 },
                 "created_at": "2015-08-25T15:16:10.000000",
                 "updated_at": "2015-08-25T15:16:10.000000",
                 "version": 2,
-                "location": "designate://v2/zones/tasks/exports/3d7d07a5-2ce3-458e-b3dd-6a29906234d8/export",
+                "location": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/3d7d07a5-2ce3-458e-b3dd-6a29906234d8/export",
                 "message": null,
                 "project_id": "noauth-project",
                 "id": "3d7d07a5-2ce3-458e-b3dd-6a29906234d8"
             },
         ],
         "links": {
-            "self": "http://127.0.0.1:9001/v2/zones/tasks/exports"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports"
         },
         "metadata": {
             "total_count": 2

--- a/api-docs/v2/api-operations/methods/GET_listZoneImport_v2__account_id__zones_tasks_imports__zone_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneImport_v2__account_id__zones_tasks_imports__zone_id__zones.rst
@@ -45,8 +45,8 @@ This table shows the URI parameters for the list a zone import request:
 
 .. code::  
 
-    GET /v2/1234/zones/tasks/imports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
-    Host: 127.0.0.1:9001
+    GET /v2/123456/zones/tasks/imports/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
 
 This operation does not accept a request body.
@@ -63,8 +63,8 @@ This operation does not accept a request body.
         "status": "COMPLETE",
         "zone_id": "6625198b-d67d-47dc-8d29-f90bd60f3ac4",
         "links": {
-            "self": "http://127.0.0.1:9001/v2/zones/tasks/imports/074e805e-fe87-4cbb-b10b-21a06e215d41",
-            "href": "http://127.0.0.1:9001/v2/zones/6625198b-d67d-47dc-8d29-f90bd60f3ac4"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/imports/074e805e-fe87-4cbb-b10b-21a06e215d41",
+            "href": "https://global.dns.rackspacecloud.com/v2/123456/zones/6625198b-d67d-47dc-8d29-f90bd60f3ac4"
         },
         "created_at": "2015-05-08T15:43:42.000000",
         "updated_at": "2015-05-08T15:43:42.000000",

--- a/api-docs/v2/api-operations/methods/GET_listZoneImports_v2__account_id__zones_tasks_imports_zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneImports_v2__account_id__zones_tasks_imports_zones.rst
@@ -42,8 +42,8 @@ This table shows the URI parameters for the list zone imports request:
 
 .. code::  
 
-    GET /v2/1234/zones/tasks/imports/ HTTP/1.1
-    Host: 127.0.0.1:9001
+    GET /v2/123456/zones/tasks/imports/ HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
 
 This operation does not accept a request body.
@@ -62,8 +62,8 @@ This operation does not accept a request body.
                 "status": "COMPLETE",
                 "zone_id": "ea2fd415-dc6d-401c-a8af-90a89d7efcf9",
                 "links": {
-                    "self": "http://127.0.0.1:9001/v2/zones/tasks/imports/fb47a23e-eb97-4c86-a3d4-f3e1a4ca9f5e",
-                    "href": "http://127.0.0.1:9001/v2/zones/ea2fd415-dc6d-401c-a8af-90a89d7efcf9"
+                    "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/imports/fb47a23e-eb97-4c86-a3d4-f3e1a4ca9f5e",
+                    "href": "https://global.dns.rackspacecloud.com/v2/123456/zones/ea2fd415-dc6d-401c-a8af-90a89d7efcf9"
                 },
                 "created_at": "2015-05-08T15:22:50.000000",
                 "updated_at": "2015-05-08T15:22:50.000000",
@@ -76,8 +76,8 @@ This operation does not accept a request body.
                 "status": "COMPLETE",
                 "zone_id": "6625198b-d67d-47dc-8d29-f90bd60f3ac4",
                 "links": {
-                    "self": "http://127.0.0.1:9001/v2/zones/tasks/imports/074e805e-fe87-4cbb-b10b-21a06e215d41",
-                    "href": "http://127.0.0.1:9001/v2/zones/6625198b-d67d-47dc-8d29-f90bd60f3ac4"
+                    "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/imports/074e805e-fe87-4cbb-b10b-21a06e215d41",
+                    "href": "https://global.dns.rackspacecloud.com/v2/123456/zones/6625198b-d67d-47dc-8d29-f90bd60f3ac4"
                 },
                 "created_at": "2015-05-08T15:43:42.000000",
                 "updated_at": "2015-05-08T15:43:42.000000",
@@ -88,7 +88,7 @@ This operation does not accept a request body.
             }
         ],
         "links": {
-            "self": "http://127.0.0.1:9001/v2/zones/tasks/imports"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/imports"
         },
         "metadata": {
             "total_count": 2

--- a/api-docs/v2/api-operations/methods/GET_listZones_v2__account_id__zones_zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZones_v2__account_id__zones_zones.rst
@@ -66,8 +66,8 @@ This table shows the URI parameters for the list zones request:
 
 .. code::  
 
-    GET /v2/1234/zones HTTP/1.1
-    Host: 127.0.0.1:9001
+    GET /v2/123456/zones HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -101,7 +101,7 @@ This operation does not accept a request body.
                 "created_at": "2014-07-07T18:25:31.275934",
                 "updated_at": null,
                 "links": {
-                    "self": "https://127.0.0.1:9001/v2/1234/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
+                    "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
                 }
             },
             {
@@ -121,12 +121,12 @@ This operation does not accept a request body.
                 "created_at": "2014-07-07T18:22:08.287743",
                 "updated_at": null,
                 "links": {
-                    "self": "https://127.0.0.1:9001/v2/1234/zones/fdd7b0dc-52a3-491e-829f-41d18e1d3ada"
+                    "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/fdd7b0dc-52a3-491e-829f-41d18e1d3ada"
                 }
             }
         ],
         "links": {
-            "self": "https://127.0.0.1:9001/v2/1234/zones"
+            "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones"
         },
         "metadata": {
             "total_count": 2

--- a/api-docs/v2/api-operations/methods/PATCH_updateZone_v2__account_id__zones__zone_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/PATCH_updateZone_v2__account_id__zones__zone_id__zones.rst
@@ -124,8 +124,8 @@ This list shows the body parameters for the request:
 
 .. code::  
 
-    PATCH /v2/1234/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
-    Host: 127.0.0.1:9001
+    PATCH /v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -158,6 +158,6 @@ This list shows the body parameters for the request:
         "created_at": "2014-07-07T18:25:31.275934",
         "updated_at": "2014-07-07T19:09:20.876366",
         "links": {
-          "self": "https://127.0.0.1:9001/v2/1234/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
         }
     }

--- a/api-docs/v2/api-operations/methods/POST_createRecordset_v2__account_id__zones__zone_id__recordsets_recordsets.rst
+++ b/api-docs/v2/api-operations/methods/POST_createRecordset_v2__account_id__zones__zone_id__recordsets_recordsets.rst
@@ -116,8 +116,8 @@ This format can be used for common record set types including A, AAAA, CNAME, NS
 
 .. code::  
 
-    POST /v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
-    Host: 127.0.0.1:9001
+    POST /v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -136,8 +136,8 @@ This format can be used for common record set types including A, AAAA, CNAME, NS
 
 .. code::  
 
-    POST /v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
-    Host: 127.0.0.1:9001
+    POST /v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -159,8 +159,8 @@ This format can be used for common record set types including A, AAAA, CNAME, NS
 
 .. code::  
 
-    POST /v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
-    Host: 127.0.0.1:9001
+    POST /v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -185,7 +185,7 @@ This format can be used for common record set types including A, AAAA, CNAME, NS
     {
         "description": "This is an example record set.",
         "links": {
-            "self": "https://127.0.0.1:9001/v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
         },
         "updated_at": null,
         "records": [
@@ -211,7 +211,7 @@ This format can be used for common record set types including A, AAAA, CNAME, NS
     {
         "description": "An MX recordset.",
         "links": {
-            "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096649"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096649"
         },
         "updated_at": null,
         "records" : [
@@ -240,7 +240,7 @@ This format can be used for common record set types including A, AAAA, CNAME, NS
     {
         "description": "A CNAME recordset.",
         "links": {
-            "self": "https://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-3765-562bc6096649"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-3765-562bc6096649"
         },
         "updated_at": null,
         "records" : [

--- a/api-docs/v2/api-operations/methods/POST_createZone_v2__account_id__zones_zones.rst
+++ b/api-docs/v2/api-operations/methods/POST_createZone_v2__account_id__zones_zones.rst
@@ -5,7 +5,7 @@ Create zone
 
 .. code::
 
-    POST /v2/{account_id}/zones
+    POST /v2/123456/zones
 
 This call provisions a new DNS zone, based on the configuration defined
 in the request object. 
@@ -124,8 +124,8 @@ This list shows the body parameters for the request:
 
 .. code::  
 
-    POST /v2/1234/zones HTTP/1.1
-    Host: 127.0.0.1:9001
+    POST /v2/123456/zones HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -161,6 +161,6 @@ This list shows the body parameters for the request:
         "created_at": "2014-07-07T18:25:31.275934",
         "updated_at": null,
         "links": {
-          "self": "https://127.0.0.1:9001/v2/1234/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
         }
     }

--- a/api-docs/v2/api-operations/methods/POST_exportZone_v2__account_id__zones__uuid_id__tasks_export_zones.rst
+++ b/api-docs/v2/api-operations/methods/POST_exportZone_v2__account_id__zones__uuid_id__tasks_export_zones.rst
@@ -44,8 +44,8 @@ request:
 
 .. code::  
 
-    POST /v2/1234/zones/074e805e-fe87-4cbb-b10b-21a06e215d41/tasks/export HTTP/1.1
-    Host: 127.0.0.1:9001
+    POST /v2/123456/zones/074e805e-fe87-4cbb-b10b-21a06e215d41/tasks/export HTTP/1.1
+    Host: global.dns.rackspacecloud.com
 
 This operation does not accept a request body.
  
@@ -60,7 +60,7 @@ This operation does not accept a request body.
         "status": "PENDING",
         "zone_id": "074e805e-fe87-4cbb-b10b-21a06e215d41",
         "links": {
-            "self": "http://127.0.0.1:9001/v2/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720"
         },
         "created_at": "2015-08-27T20:57:03.000000",
         "updated_at": null,

--- a/api-docs/v2/api-operations/methods/POST_importZone_v2__account_id__zones_tasks_imports_zones.rst
+++ b/api-docs/v2/api-operations/methods/POST_importZone_v2__account_id__zones_tasks_imports_zones.rst
@@ -5,7 +5,7 @@ Create a zone import
 
 .. code::
 
-    POST /v2/{account_id}/zones/tasks/imports
+    POST /v2/123456/zones/tasks/imports
 
 This call imports a zonefile. To import a zonefile, set the Content-type to ``text/dns``. 
 The **zoneextractor.py** tool in the ``contrib`` folder can generate zonefiles that are 
@@ -48,8 +48,8 @@ request:
 
 .. code::  
 
-    POST /v2/1234/zones/tasks/imports HTTP/1.1
-    Host: 127.0.0.1:9001
+    POST /v2/123456/zones/tasks/imports HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Content-type: text/dns
 
     $ORIGIN example.com.
@@ -73,7 +73,7 @@ This operation does not accept a request body.
         "status": "PENDING",
         "zone_id": null,
         "links": {
-            "self": "http://127.0.0.1:9001/v2/zones/tasks/imports/074e805e-fe87-4cbb-b10b-21a06e215d41"
+            "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/imports/074e805e-fe87-4cbb-b10b-21a06e215d41"
         },
         "created_at": "2015-05-08T15:43:42.000000",
         "updated_at": null,

--- a/api-docs/v2/api-operations/methods/PUT_updateRecordset_v2__account_id__zones__zone_id__recordsets__recordset_id__recordsets.rst
+++ b/api-docs/v2/api-operations/methods/PUT_updateRecordset_v2__account_id__zones__zone_id__recordsets__recordset_id__recordsets.rst
@@ -109,8 +109,8 @@ This list shows the body parameters for the request:
 
 .. code::  
 
-    PUT /v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648 HTTP/1.1
-    Host: 127.0.0.1:9001
+    PUT /v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648 HTTP/1.1
+    Host: global.dns.rackspacecloud.com
     Accept: application/json
     Content-Type: application/json
 
@@ -137,7 +137,7 @@ This list shows the body parameters for the request:
             "10.1.0.2"
         ],
         "links": {
-            "self": "https://127.0.0.1:9001/v2/1234/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
         },
         "updated_at": "2014-10-24T20:15:27.000000",
         "id": "f7b10e9b-0cae-4a91-b162-562bc6096648",

--- a/api-docs/v2/common-gs/auth-using-curl.rst
+++ b/api-docs/v2/common-gs/auth-using-curl.rst
@@ -93,7 +93,7 @@ token ID
     
 tenant ID
     The tenant ID provides your account number. For most Rackspace Cloud service APIs, the 
-    tenant ID is appended to the API endpoint in the service catalog automatically. You 
+    tenant ID is appended to the API endpoint in the service catalog automatically. 
      
 endpoint 
 	The API endpoint provides the URL that you use to access the API service. For guidance 

--- a/api-docs/v2/concepts.rst
+++ b/api-docs/v2/concepts.rst
@@ -32,8 +32,8 @@ records. Zones may also be referred to as domains.
 
 .. _concept-subzone:
 
-Subzone
--------
+Subzone (Subdomain)
+-------------------
 
 Also known as second level or child zones, a subzone is any zone that is part of a larger
 zone. Subzones allow you to divide and delegate a zone, also called a parent zone. Subzones 

--- a/api-docs/v2/general-api-info/descriptions.rst
+++ b/api-docs/v2/general-api-info/descriptions.rst
@@ -21,7 +21,7 @@ Descriptions are supported for requests and responses of zones and recordsets us
       "masters": null,
       "name": "example.com.",
       "links": {
-        "self": "http://127.0.0.1:9001/v2/zones/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx"
+        "self": "https://global.dns.rackspacecloud.com/v2/123456/zones/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx"
       },
       "transferred_at": null,
       "created_at": "2015-07-22T15:55:47.000000",

--- a/api-docs/v2/general-api-info/dns-service-versions.rst
+++ b/api-docs/v2/general-api-info/dns-service-versions.rst
@@ -19,6 +19,6 @@ one another.
 
 .. code::
 
-    https://dns.api.rackspacecloud.com/v2.0/zones
+    https://global.dns.api.rackspacecloud.com/v2.0/zones
 
 .. note:: This request URL pertains to contract version 2.0.

--- a/api-docs/v2/general-api-info/filtering.rst
+++ b/api-docs/v2/general-api-info/filtering.rst
@@ -50,11 +50,11 @@ The following example takes a collection of zones and filters it by the â€œnameâ
         "project_id": "noauth-project",
         "email": "hostmaster@example.com",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
         }
       }],
       "links": {
-        "self": "https://global.dns.api.rackspacecloud.com/v2/zones?name=example.com."
+        "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones?name=example.com."
       }
     } 
 
@@ -94,7 +94,7 @@ use of wildcards on the right side of a query:
         "project_id": "noauth-project",
         "email": "hostmaster@example.com",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
         }
       },
       {
@@ -111,11 +111,11 @@ use of wildcards on the right side of a query:
         "project_id": "noauth-project",
         "email": "hostmaster@example.org",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/38dbf635-45cb-4873-8300-6c273f0283c7"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/38dbf635-45cb-4873-8300-6c273f0283c7"
         }
       }],
       "links": {
-        "self": "https://global.dns.api.rackspacecloud.com/v2/zones?name=example*"
+        "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones?name=example*"
       }
     } 
 
@@ -154,7 +154,7 @@ This example demonstrates the use of multiple wildcards:
         "project_id": "noauth-project",
         "email": "hostmaster@example.com",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
         }
       },
       {
@@ -171,7 +171,7 @@ This example demonstrates the use of multiple wildcards:
         "project_id": "noauth-project",
         "email": "hostmaster@example.com",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/13db810b-917d-4898-bc28-4d4ee370d20d"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/13db810b-917d-4898-bc28-4d4ee370d20d"
         }
       },
       {
@@ -188,7 +188,7 @@ This example demonstrates the use of multiple wildcards:
         "project_id": "noauth-project",
         "email": "hostmaster@example.org",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/38dbf635-45cb-4873-8300-6c273f0283c7"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/38dbf635-45cb-4873-8300-6c273f0283c7"
         }
       },
       {
@@ -205,10 +205,10 @@ This example demonstrates the use of multiple wildcards:
         "project_id": "noauth-project",
         "email": "hostmaster@example.net",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/c316def0-8599-4030-9dcd-2ce566348115"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/c316def0-8599-4030-9dcd-2ce566348115"
         }
       }],
       "links": {
-        "self": "https://global.dns.api.rackspacecloud.com/v2/zones?name=*example*"
+        "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones?name=*example*"
       }
     }

--- a/api-docs/v2/general-api-info/pagination.rst
+++ b/api-docs/v2/general-api-info/pagination.rst
@@ -49,7 +49,7 @@ or ``email``). To sort in descending order, specify add the ``sort_dir=DESC`` qu
         "project_id": "noauth-project",
         "email": "hostmaster@example.net",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/c316def0-8599-4030-9dcd-2ce566348115"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/c316def0-8599-4030-9dcd-2ce566348115"
         }
       },
       {
@@ -66,11 +66,11 @@ or ``email``). To sort in descending order, specify add the ``sort_dir=DESC`` qu
         "project_id": "noauth-project",
         "email": "hostmaster@example.com",
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
         }
       }
       }],
       "links": {
-        "self": "https://global.dns.api.rackspacecloud.com/v2/zones?sort_key=id&sort_dir=desc"
+        "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones?sort_key=id&sort_dir=desc"
       }
     }

--- a/api-docs/v2/general-api-info/resources.rst
+++ b/api-docs/v2/general-api-info/resources.rst
@@ -24,7 +24,7 @@ a ``self`` link that points to the given resource.
          "id": "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
          "....": "....",
          "links": {
-           "self": "https://dns.api.rackspacecloud.com/v2/examples/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
+           "self": "https://global.dns.api.rackspacecloud.com/v2/examples/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
          }
        }
      } 

--- a/api-docs/v2/general-api-info/service-access-endpoints.rst
+++ b/api-docs/v2/general-api-info/service-access-endpoints.rst
@@ -7,10 +7,9 @@ Because |product name| service is not a regionalized service, the service is the
 responsible for appropriate replication, caching, and overall maintenance of DNS data 
 across regional boundaries to other DNS servers.
 
-Use one of the following service access/endpoint to access the |product name| service:
+Use the following service access/endpoint to access the |product name| service:
 
-- ``https://dns.api.rackspacecloud.com/v1.0/1234/``
-- ``https://lon.dns.api.rackspacecloud.com/v1.0/1234/``
+- ``https://global.dns.api.rackspacecloud.com/v2/123456/``
 
 Replace the sample account ID number, ``1234``, with your Rackspace Cloud account number.
 
@@ -21,5 +20,5 @@ catalog, see the :ref:`authentication response example <review-auth-resp>`.
 ..  note::
     The service catalog returned in the auth response specifies the correct service access 
     endpoint for your account to use for accessing |product name|. Use the service type 
-    (rax:dns) to locate the correct endpoint in the service catalog. For an example of the 
+    (dns) to locate the correct endpoint in the service catalog. For an example of the 
     service catalog, see :ref:`authentication response examples <review-auth-resp>`.

--- a/api-docs/v2/general-api-info/supported-record-types.rst
+++ b/api-docs/v2/general-api-info/supported-record-types.rst
@@ -42,7 +42,7 @@ Record Type: **CNAME** (Creates an alias for a zone)
   	   A CNAME record label (name) can have underscores anywhere in any subzone labels, 
   	   but not in the main zone name of the zone to which the record belongs. For example, 
   	   for the zone *example.com*, a CNAME record belonging to that zone can have the label 
-  	   ``_ab_b_.cd_e.example.com``.
+  	   ``_ab_b_.cd_e.example.com.``.
 
 Record Type: **MX** (Designates a zone's mail server)
 
@@ -57,7 +57,7 @@ Record Type: **MX** (Designates a zone's mail server)
   	.. note::
   	
   	   The MX record set data format is “<priority> <host>”, so in the preceding recordset 
-  	   example, the priority = ``10`` and host = ``mail.example.com``.
+  	   example, the priority = ``10`` and host = ``mail.example.com.``.
   	   
 Record Type: **NS** (Designates a zone's authoritative name server)
 
@@ -67,7 +67,7 @@ Record Type: **NS** (Designates a zone's authoritative name server)
          "description" : "This is an example NS record set.",
          "type" : "NS",
          "ttl" : 3600,
-         "records" : [ "ns1.com" ] }
+         "records" : [ "ns1.com." ] }
 
 Record Type: **PTR** (Designates a reverse DNS record)
 

--- a/api-docs/v2/general-api-info/synchronous-and-asynchronous-responses.rst
+++ b/api-docs/v2/general-api-info/synchronous-and-asynchronous-responses.rst
@@ -32,13 +32,13 @@ example:
 
 .. code::
 
-	`https://dns.api.rackspacecloud.com/v2/1234/zones <http://localhost:9001/v2/zones>`__.
+	`https://global.dns.api.rackspacecloud.com/v2/123456/zones`__.
 	
 You can filter collections by status. For example:
 
 .. code::
 
-	`https://dns.api.rackspacecloud.com/v2/1234/zones?status=PENDING <http://localhost:9001/v2/zones?status=PENDING>`__.
+	`https://global.dns.api.rackspacecloud.com/v2/123456/zones?status=PENDING`__.
 	
 Method 2:
 
@@ -61,5 +61,5 @@ property. If the job is complete, the ``status`` field will be ``ACTIVE``..  For
       "project_id": "noauth-project",
       "email": "hostmaster@example.com",
       "links": {
-      "self": "http://dns.provider.com/v2/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
+      "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
     }

--- a/api-docs/v2/getting-started/examples/cli-create-zone.rst
+++ b/api-docs/v2/getting-started/examples/cli-create-zone.rst
@@ -49,8 +49,8 @@ The response is similar to the following:
 
     .. code::  
 
-       Failed to contact the endpoint at  https://global.dns.api.rackspacecloud.com/v2/938611 
-       for discovery. Fallback to  using that endpoint as the base url. 
+       Failed to contact the endpoint at https://global.dns.api.rackspacecloud.com/v2/123456 
+       for discovery. Fallback to using that endpoint as the base url. 
 
 This request is asynchronous. So the ``status`` is set to ``PENDING`` when the zone is 
 initially created. When the zone is created completely, the status is set to ``ACTIVE``. 

--- a/api-docs/v2/getting-started/examples/curl-create-recordset.rst
+++ b/api-docs/v2/getting-started/examples/curl-create-recordset.rst
@@ -21,7 +21,7 @@ The following examples show the cURL request for Create recordset:
     }' \
     -H "X-Auth-Token: $token" \
     -H "Content-Type: application/json" \
-    https://global.dns.api.rackspacecloud.com/v2/$account/zones/zone_id/recordsets | python -m json.tool
+    https://global.dns.api.rackspacecloud.com/v2/123456/zones/zone_id/recordsets | python -m json.tool
 
 Remember to replace the names in the examples above with their actual respective values:
 
@@ -54,7 +54,7 @@ The following example shows the response for Create recordset:
         "action": "CREATE",
         "description": "This is an example record set.",
         "links": {
-            "self": "https://global.dns.api.rackspacecloud.com/v2/$account/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
         }
     }
 

--- a/api-docs/v2/getting-started/examples/curl-create-zone.rst
+++ b/api-docs/v2/getting-started/examples/curl-create-zone.rst
@@ -21,7 +21,7 @@ The following example shows the cURL request for Create zone:
     }' \
     -H "X-Auth-Token: $token" \
     -H "Content-Type: application/json" \
-    https://global.dns.api.rackspacecloud.com/v2/$account/zones | python -m json.tool
+    https://global.dns.api.rackspacecloud.com/v2/123456/zones | python -m json.tool
 
 Remember to replace the names in the examples above with their actual respective values 
 for all the cURL examples that follow:
@@ -56,7 +56,7 @@ The following example shows the initial asynchronous responses for **Create zone
         "created_at": "2015-06-18T18:25:31.275934",
         "updated_at": null,
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
         }
     }
 

--- a/api-docs/v2/getting-started/examples/curl-list-recordset.rst
+++ b/api-docs/v2/getting-started/examples/curl-list-recordset.rst
@@ -13,7 +13,7 @@ The following example shows the cURL request for List recordset:
     curl -s \
     -H "X-Auth-Token: $token" \
     -H "Content-Type: application/json" \
-    https://global.dns.api.rackspacecloud.com/v2/$account/zones/zone_id/recordsets/recordset_id | python -m json.tool
+    https://global.dns.api.rackspacecloud.com/v2/123456/zones/zone_id/recordsets/recordset_id | python -m json.tool
 
 Remember to replace the names in the examples above with their actual respective values:
 
@@ -47,7 +47,7 @@ The following example shows the response for List recordset:
         "action": "NONE",
      "description": "This is an example record set.",
         "links": {
-            "self": "https://global.dns.api.rackspacecloud.com/v2/$account/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
+            "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets/f7b10e9b-0cae-4a91-b162-562bc6096648"
         },
     }
 

--- a/api-docs/v2/getting-started/examples/curl-list-zone.rst
+++ b/api-docs/v2/getting-started/examples/curl-list-zone.rst
@@ -14,7 +14,7 @@ The following example shows the cURL request for List zone:
     curl -s  \
     -H "X-Auth-Token: $token"  \
     -H "Accept: application/json"  \
-    https://global.dns.api.rackspacecloud.com/v2/$account/zones/zone_id | python -m json.tool
+    https://global.dns.api.rackspacecloud.com/v2/123456/zones/zone_id | python -m json.tool
 
 Remember to replace the names in the examples above with their actual respective values 
 for all the cURL examples that follow:
@@ -49,7 +49,7 @@ The following example shows the List zone response:
         "created_at": "2015-06-18T18:25:31.275934",
         "updated_at": null,
         "links": {
-          "self": "https://global.dns.api.rackspacecloud.com/v2/$account/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
+          "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3"
         }
     }
 

--- a/api-docs/v2/getting-started/index.rst
+++ b/api-docs/v2/getting-started/index.rst
@@ -7,6 +7,7 @@
 .. toctree::
     :maxdepth: 2
 
+    Name server setup with your Registrar <name-server-setup>
     Prerequisites <prerequisites-for-using-api>
     Designate client <designate-client>
     Install CLI client <install-CLI-client>

--- a/api-docs/v2/getting-started/install-CLI-client.rst
+++ b/api-docs/v2/getting-started/install-CLI-client.rst
@@ -49,3 +49,5 @@ run the following command:
 .. code::  
 
     $ sudo pip install -U distribute
+
+Now that your command line tool is ready, jump to :ref:`Creating a zone with the CLI<cli-create-zone>`.

--- a/api-docs/v2/getting-started/name-server-setup.rst
+++ b/api-docs/v2/getting-started/name-server-setup.rst
@@ -1,0 +1,15 @@
+.. _name-server-setup:
+
+Name server setup with your Domain Registrar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before beginning, you should configure the name servers for your domain. This can be done
+through your domain name registrar or by delegating a sub-zone from another zone. Without
+this step, your domain will not resolve.
+
+|product name| Name Servers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Set the following name servers with your domain name registrar or parent zone.
+
+ - `ns.rackspace.com`
+ - `ns2.rackspace.com`

--- a/api-docs/v2/getting-started/using-cloud-dns.rst
+++ b/api-docs/v2/getting-started/using-cloud-dns.rst
@@ -24,10 +24,9 @@ In this case, assume that you want to create a zone using ``name=example.org``.
 
 ..  note:: 
 
-   If you want to substitute your own zone name, you can use any letter, numbers between 
-   0 and 9, and the character "-". For example, you might use your first name and last 
-   initial at the beginning of the name (for example, "bobmexample.org"). Ensure that you 
-   add the final period (.) at the end of your fully qualified zone name.
+   **Zone naming** You can use any letter, number from 0 to 9, and the character 
+   `-`. Ensure that you add the final period (.) at the end of your fully qualified 
+   zone name (e.g. `example1234.com.`).
 
 
 Choose one of the following methods:


### PR DESCRIPTION
- fixed incorrect API endpoints listed
- replace http with https
- v2 examples are missing tenant in the URL
- `example.com"` is missing the trailing dot
- Record Type: NS is missing trailling dot in ns1.com
- add convenient link to creating a resource in CLI from CLI install "Creating a zone with the CLI"
- "tenant ID" has some text missing at the end "You"
- "If you want to substitute your own zone name" - simplified the text.
- double spaces in "Failed to contact the endpoint at"
- replace all instances of $account with the sample account number
- add docs for ns.rackspace.com listed anywhere
- https://127.0.0.1:9001, http://127.0.0.1:9001, and 127.0.0.1:9001 needs to be updated
- "designate://" is in some url fields
- "/v2/zones/" is missing the tenant number