### PR TITLE
Applied changes from Joe's Etherpad Notes

### DIFF
--- a/api-docs/v2/api-operations/methods/DELETE_deleteZone_v2__account_id__zones__zone_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/DELETE_deleteZone_v2__account_id__zones__zone_id__zones.rst
@@ -63,10 +63,6 @@ This table shows the possible response codes for this operation:
 +---------+-----------------------+---------------------------------------------+
 | 503     | Service Unavailable   | The service is not available.               |
 +---------+-----------------------+---------------------------------------------+
-| 513     | Global Rate Limit     | The service is under high load and the      |
-|         |                       | request was rate limited. Try again in a    |
-|         |                       | few minutes.                                |
-+---------+-----------------------+---------------------------------------------+
 
 This table shows the URI parameters for the delete zone request:
 

--- a/api-docs/v2/api-operations/methods/GET_listZoneExport_v2__account_id__zones_tasks_exports__uuid_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneExport_v2__account_id__zones_tasks_exports__uuid_id__zones.rst
@@ -70,7 +70,7 @@ This operation does not accept a request body.
         "version": 2,
         "location": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720/export",
         "message": null,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "id": "8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720"
     }
 

--- a/api-docs/v2/api-operations/methods/GET_listZoneExports_v2__account_id__zones_tasks_exports_zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneExports_v2__account_id__zones_tasks_exports_zones.rst
@@ -7,7 +7,7 @@ List zone exports
 
     GET /v2/{TENANT_ID}/zones/tasks/exports
 
-This call lists all of the zone exports created by this project. Returned objects can be 
+This call lists all of the zone exports created by this account. Returned objects can be 
 queried using the links in the ``links`` field.
 
 This table shows the possible response codes for this operation:
@@ -69,7 +69,7 @@ This operation does not accept a request body.
                 "version": 2,
                 "location": "https://global.dns.rackspacecloud.com/v2/123456/zones/30ea7692-7f9e-4195-889e-0ba11620b491/tasks/exports/d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248/export",
                 "message": null,
-                "project_id": "noauth-project",
+                "project_id": "123456",
                 "id": "d2f36aa6-2da4-4b22-a2a9-9cdf19a2f248"
             },
             {
@@ -84,7 +84,7 @@ This operation does not accept a request body.
                 "version": 2,
                 "location": "https://global.dns.rackspacecloud.com/v2/123456/zones/tasks/exports/3d7d07a5-2ce3-458e-b3dd-6a29906234d8/export",
                 "message": null,
-                "project_id": "noauth-project",
+                "project_id": "123456",
                 "id": "3d7d07a5-2ce3-458e-b3dd-6a29906234d8"
             },
         ],

--- a/api-docs/v2/api-operations/methods/GET_listZoneImport_v2__account_id__zones_tasks_imports__zone_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneImport_v2__account_id__zones_tasks_imports__zone_id__zones.rst
@@ -70,7 +70,7 @@ This operation does not accept a request body.
         "updated_at": "2015-05-08T15:43:42.000000",
         "version": 2,
         "message": "example.com. imported",
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "id": "074e805e-fe87-4cbb-b10b-21a06e215d41"
     }
 

--- a/api-docs/v2/api-operations/methods/GET_listZoneImports_v2__account_id__zones_tasks_imports_zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZoneImports_v2__account_id__zones_tasks_imports_zones.rst
@@ -7,7 +7,7 @@ List zone imports
 
     GET /v2/{TENANT_ID}/zones/tasks/imports
 
-This call lists all of the zone imports created by this project. Objects will be returned 
+This call lists all of the zone imports created by this account. Objects will be returned 
 that can be queried using the links in the ``links`` field.
 
 This table shows the possible response codes for this operation:
@@ -69,7 +69,7 @@ This operation does not accept a request body.
                 "updated_at": "2015-05-08T15:22:50.000000",
                 "version": 2,
                 "message": "example.com. imported",
-                "project_id": "noauth-project",
+                "project_id": "123456",
                 "id": "fb47a23e-eb97-4c86-a3d4-f3e1a4ca9f5e"
             },
             {
@@ -83,7 +83,7 @@ This operation does not accept a request body.
                 "updated_at": "2015-05-08T15:43:42.000000",
                 "version": 2,
                 "message": "example.com. imported",
-                "project_id": "noauth-project",
+                "project_id": "123456",
                 "id": "074e805e-fe87-4cbb-b10b-21a06e215d41"
             }
         ],

--- a/api-docs/v2/api-operations/methods/GET_listZones_v2__account_id__zones_zones.rst
+++ b/api-docs/v2/api-operations/methods/GET_listZones_v2__account_id__zones_zones.rst
@@ -87,7 +87,7 @@ This operation does not accept a request body.
             {
                 "id": "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
                 "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
-                "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+                "project_id": "123456",
                 "name": "example.org.",
                 "email": "joe@example.org.",
                 "ttl": 7200,
@@ -107,7 +107,7 @@ This operation does not accept a request body.
             {
                 "id": "fdd7b0dc-52a3-491e-829f-41d18e1d3ada",
                 "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
-                "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+                "project_id": "123456",
                 "name": "example.net.",
                 "email": "joe@example.net.",
                 "ttl": 7200,

--- a/api-docs/v2/api-operations/methods/PATCH_updateZone_v2__account_id__zones__zone_id__zones.rst
+++ b/api-docs/v2/api-operations/methods/PATCH_updateZone_v2__account_id__zones__zone_id__zones.rst
@@ -144,7 +144,7 @@ This list shows the body parameters for the request:
     {
         "id": "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
-        "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+        "project_id": "123456",
         "name": "example.org.",
         "email": "joe@example.org.",
         "ttl": 3600,

--- a/api-docs/v2/api-operations/methods/POST_createZone_v2__account_id__zones_zones.rst
+++ b/api-docs/v2/api-operations/methods/POST_createZone_v2__account_id__zones_zones.rst
@@ -77,10 +77,6 @@ This table shows the possible response codes for this operation:
 +---------+-----------------------+---------------------------------------------+
 | 503     | Service Unavailable   | The service is not available.               |
 +---------+-----------------------+---------------------------------------------+
-| 513     | Global Rate Limit     | The service is under high load and the      |
-|         |                       | request was rate limited. Try again in a    |
-|         |                       | few minutes.                                |
-+---------+-----------------------+---------------------------------------------+
 
 This table shows the URI parameters for the create zone request:
 
@@ -147,7 +143,7 @@ This list shows the body parameters for the request:
     {
         "id": "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
-        "project_id": "4335d1f0-f793-11e2-b778-0800200c9a66",
+        "project_id": "123456",
         "name": "example.org.",
         "email": "joe@example.org",
         "ttl": 7200,

--- a/api-docs/v2/api-operations/methods/POST_exportZone_v2__account_id__zones__uuid_id__tasks_export_zones.rst
+++ b/api-docs/v2/api-operations/methods/POST_exportZone_v2__account_id__zones__uuid_id__tasks_export_zones.rst
@@ -67,6 +67,6 @@ This operation does not accept a request body.
         "version": 1,
         "location": null,
         "message": null,
-        "project_id": "1",
+        "project_id": "123456",
         "id": "8ec17fe1-d1f9-41b4-aa98-4eeb4c27b720"
     }

--- a/api-docs/v2/api-operations/methods/POST_importZone_v2__account_id__zones_tasks_imports_zones.rst
+++ b/api-docs/v2/api-operations/methods/POST_importZone_v2__account_id__zones_tasks_imports_zones.rst
@@ -28,10 +28,6 @@ This table shows the possible response codes for this operation:
 |         |                       | requested resource for the requested        |
 |         |                       | method.                                     |
 +---------+-----------------------+---------------------------------------------+
-| 513     | Global Rate Limit     | The service is under high load and the      |
-|         |                       | request was rate limited. Try again in a    |
-|         |                       | few minutes.                                |
-+---------+-----------------------+---------------------------------------------+
 
 This table shows the URI parameters for the create a zone import
 request:
@@ -79,6 +75,6 @@ This operation does not accept a request body.
         "updated_at": null,
         "version": 1,
         "message": null,
-        "project_id": "1",
+        "project_id": "123456",
         "id": "074e805e-fe87-4cbb-b10b-21a06e215d41"
     }

--- a/api-docs/v2/common-gs/how-to-use-curl.rst
+++ b/api-docs/v2/common-gs/how-to-use-curl.rst
@@ -62,11 +62,6 @@ The cURL examples in this guide use the following command-line options.
 |           |                                                                       |
 |           | - Specifies the authentication token.                                 |
 |           |                                                                       |
-|           | ``X-Auth-Project-Id``: Optional.                                      |
-|           |                                                                       |
-|           | - Specifies the project ID, which can be your account number or       |
-|           |   another value.                                                      |
-|           |                                                                       |
 |           | ``Accept``: Optional.                                                 |
 |           |                                                                       |
 |           | - Specifies the format of the response body. Following is the syntax  |

--- a/api-docs/v2/general-api-info/descriptions.rst
+++ b/api-docs/v2/general-api-info/descriptions.rst
@@ -32,7 +32,7 @@ Descriptions are supported for requests and responses of zones and recordsets us
       "ttl": 3600,
       "action": "NONE",
       "serial": 1437580547,
-      "project_id": "noauth-project",
+      "project_id": "123456",
       "type": "PRIMARY",
       "email": "user@example.org",
       "description": "Optional zone description"

--- a/api-docs/v2/general-api-info/errors.rst
+++ b/api-docs/v2/general-api-info/errors.rst
@@ -35,8 +35,6 @@ descriptions.
 +----------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Internal Server Error| 500  | The back-end services encountered an unexpected condition that prevented it from fulfilling the request. See the details element for specifics.                                                                                                   |
 +----------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Global Rate Limit    | 513  | The system is under peak load and new requests are being rate limited. Please try again.                                                                                                                                                          |
-+----------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 All errors will look similar. A ``code`` element will show the HTTP error code for convenience.
 The ``type`` element will show the type of error. The ``request_id`` will help API operators

--- a/api-docs/v2/general-api-info/filtering.rst
+++ b/api-docs/v2/general-api-info/filtering.rst
@@ -47,7 +47,7 @@ The following example takes a collection of zones and filters it by the â€œnameâ
         "created_at": "2014-07-08T20:28:19.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.com",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
@@ -91,7 +91,7 @@ use of wildcards on the right side of a query:
         "created_at": "2014-07-08T20:28:19.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.com",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
@@ -108,7 +108,7 @@ use of wildcards on the right side of a query:
         "created_at": "2014-07-15T14:39:02.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.org",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/38dbf635-45cb-4873-8300-6c273f0283c7"
@@ -151,7 +151,7 @@ This example demonstrates the use of multiple wildcards:
         "created_at": "2014-07-08T20:28:19.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.com",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"
@@ -168,7 +168,7 @@ This example demonstrates the use of multiple wildcards:
         "created_at": "2014-07-15T14:38:19.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.com",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/13db810b-917d-4898-bc28-4d4ee370d20d"
@@ -185,7 +185,7 @@ This example demonstrates the use of multiple wildcards:
         "created_at": "2014-07-15T14:39:02.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.org",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/38dbf635-45cb-4873-8300-6c273f0283c7"
@@ -202,7 +202,7 @@ This example demonstrates the use of multiple wildcards:
         "created_at": "2014-07-15T14:39:16.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.net",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/c316def0-8599-4030-9dcd-2ce566348115"

--- a/api-docs/v2/general-api-info/limits.rst
+++ b/api-docs/v2/general-api-info/limits.rst
@@ -62,7 +62,7 @@ resource a user is allowed to create.
 Zone quotas
 ^^^^^^^^^^^
 
-By default users may have up to 500 zones per Cloud account (including sub-zones). When
+By default users may have up to 5000 zones per Cloud account (including sub-zones). When
 a user submits a request to create new zones, the system will only accept the request if the
 total number of existing plus requested zones is within the account zone limit. If the total
 exceeds the account zone limit, the entire request will be rejected and the following message

--- a/api-docs/v2/general-api-info/limits.rst
+++ b/api-docs/v2/general-api-info/limits.rst
@@ -56,7 +56,7 @@ the request should be retried in a few minutes.
 Resource Quotas
 ~~~~~~~~~~~~~~~
 
-**POST**, **PUT**, and **PATCH** ccalls are subject to quotas for the number of a certain 
+**POST**, **PUT**, and **PATCH** calls are subject to quotas for the number of a certain 
 resource a user is allowed to create.
 
 Zone quotas

--- a/api-docs/v2/general-api-info/pagination.rst
+++ b/api-docs/v2/general-api-info/pagination.rst
@@ -6,7 +6,9 @@ Pagination and Sorting
 Pagination and sorting is available on all collections and is controlled using a combination 
 of four query parameters: ``marker=<UUID>&limit=<INTEGER>&sort_key=<STRING>&sort_dir<STRING>``. 
 
-Collection responses will include a ``links`` object containing absolute URLs for the next and previous pages. These links may be omitted, or null, at the edges of a paginated collection.
+Collection responses will include a ``links`` object containing absolute URLs for the next 
+and previous pages. These links may be omitted, or null, at the edges of a paginated 
+collection.
 
 To navigate the collection, the parameters ``limit`` and ``marker`` can be set in the URI 
 (for example: ``?limit=100&marker=<UUID>``). The ``marker`` parameter is the ID of the last 
@@ -46,7 +48,7 @@ or ``email``). To sort in descending order, specify add the ``sort_dir=DESC`` qu
         "created_at": "2014-07-15T14:39:16.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.net",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/c316def0-8599-4030-9dcd-2ce566348115"
@@ -63,7 +65,7 @@ or ``email``). To sort in descending order, specify add the ``sort_dir=DESC`` qu
         "created_at": "2014-07-08T20:28:19.000000",
         "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
         "version": 1,
-        "project_id": "noauth-project",
+        "project_id": "123456",
         "email": "hostmaster@example.com",
         "links": {
           "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"

--- a/api-docs/v2/general-api-info/role-based-access-control.rst
+++ b/api-docs/v2/general-api-info/role-based-access-control.rst
@@ -4,6 +4,11 @@
 Role Based Access Control
 =========================
 
+.. important::
+
+   Role based access control does not apply during the EA release period.  This section
+   is intended only for future releases.
+
 Role Based Access Control (RBAC) restricts access to the capabilities of Rackspace Cloud 
 services, including the Cloud DNS API, to authorized users only. RBAC enables Rackspace 
 Cloud customers to specify which account users of their Cloud account have access to which 

--- a/api-docs/v2/general-api-info/synchronous-and-asynchronous-responses.rst
+++ b/api-docs/v2/general-api-info/synchronous-and-asynchronous-responses.rst
@@ -32,13 +32,13 @@ example:
 
 .. code::
 
-	`https://global.dns.api.rackspacecloud.com/v2/123456/zones`__.
+	`https://global.dns.api.rackspacecloud.com/v2/123456/zones`.
 	
 You can filter collections by status. For example:
 
 .. code::
 
-	`https://global.dns.api.rackspacecloud.com/v2/123456/zones?status=PENDING`__.
+	`https://global.dns.api.rackspacecloud.com/v2/123456/zones?status=PENDING`.
 	
 Method 2:
 
@@ -58,7 +58,7 @@ property. If the job is complete, the ``status`` field will be ``ACTIVE``..  For
       "created_at": "2014-07-08T20:28:19.000000",
       "pool_id": "572ba08c-d929-4c70-8e42-03824bb24ca2",
       "version": 1,
-      "project_id": "noauth-project",
+      "project_id": "123456",
       "email": "hostmaster@example.com",
       "links": {
       "self": "https://global.dns.api.rackspacecloud.com/v2/123456/zones/a4e29ed3-d7a4-4e4d-945d-ce64678d3b94"

--- a/api-docs/v2/getting-started/examples/cli-create-zone.rst
+++ b/api-docs/v2/getting-started/examples/cli-create-zone.rst
@@ -33,7 +33,7 @@ The response is similar to the following:
     | masters        |                                      |
     | name           | example.org.                         |
     | pool_id        | 794ccc2c-d751-44fe-b57f-8894c9f5c842 |
-    | project_id     | 938611                               |
+    | project_id     | 123456                               |
     | serial         | 1446155649                           |
     | status         | PENDING                              |
     | transferred_at | None                                 |

--- a/api-docs/v2/getting-started/examples/cli-list-zone.rst
+++ b/api-docs/v2/getting-started/examples/cli-list-zone.rst
@@ -28,7 +28,7 @@ The response is similar to the following:
     | masters        |                                      |
     | name           | example.org.                         |
     | pool_id        | 794ccc2c-d751-44fe-b57f-8894c9f5c842 |
-    | project_id     | 938611                               |
+    | project_id     | 123456                               |
     | serial         | 1446155649                           |
     | status         | ACTIVE                               |
     | transferred_at | None                                 |

--- a/api-docs/v2/release-notes/cdns-v2-20151112.rst
+++ b/api-docs/v2/release-notes/cdns-v2-20151112.rst
@@ -3,7 +3,7 @@ v2 Preview release, November 12, 2015
 
 What's new
 ~~~~~~~~~~
-This version contains the preview release for |product name|. 
+This version contains the internal-only preview release for |product name|. 
 
 During the preview, please send your feedback to: <ManagedDNS_Preview@rackspace.com>.
 


### PR DESCRIPTION
Including making sure xml formatting is not mentioned, removing a pair of double underscores, removing the error 513 rows form error tables, corrected spelling of calls, corrected project id in examples to "123456", removed X-Auth-Project-id, added comment the RBAC doesn't apply to EA, noted that the preview release was only internal.