### PR TITLE
Don't mention support of the .json extension

### DIFF
--- a/api-docs/v2/general-api-info/request-response-types.rst
+++ b/api-docs/v2/general-api-info/request-response-types.rst
@@ -5,8 +5,6 @@ Request and response types
 
 The |apiservice| supports the JSON data serialization formats. The request format is 
 specified using the ``Content-Type`` header and is required for calls that have a request 
-body. The response format can be specified in requests either by using the ``Accept`` 
-header or by adding a ``.json`` extension to the request URI. If no response format is 
-specified, JSON is the default. If conflicting formats are specified using both an ``Accept`` 
-header and a query extension, the query extension takes precedence.
+body. The response format is specified in requests by using the ``Accept`` header. If no 
+response format is specified, JSON is the default.
 


### PR DESCRIPTION
Unless this is standard across Rackspace products, using `<url>.json` in place of the `Accept` header is not something the team knew about and not something we intend to support.