### PR TITLE
Fix broken KC links (both v1 and v2)

### DIFF
--- a/api-docs/v1/general-api-info/role-based-access-control.rst
+++ b/api-docs/v1/general-api-info/role-based-access-control.rst
@@ -4,14 +4,26 @@
 Role Based Access Control
 =========================
 
-Role Based Access Control (RBAC) restricts access to the capabilities of Rackspace Cloud services, including the Cloud DNS API, to authorized users only. RBAC enables Rackspace Cloud customers to specify which account users of their Cloud account have access to which Cloud DNS API service capabilities, based on roles defined by Rackspace (see Cloud DNS Product Roles and Permissions). The permissions to perform certain operations in Cloud DNS API – create, read, update, delete – are assigned to specific roles. The account owner user assigns these roles, either global (multiproduct) or product-specific (for example, Cloud DNS), to account users.
+Role Based Access Control (RBAC) restricts access to the capabilities of Rackspace Cloud 
+services, including the Cloud DNS API, to authorized users only. RBAC enables Rackspace 
+Cloud customers to specify which account users of their Cloud account have access to which 
+Cloud DNS API service capabilities, based on roles defined by Rackspace (see Cloud DNS 
+Product Roles and Permissions). The permissions to perform certain operations in Cloud DNS 
+API – create, read, update, delete – are assigned to specific roles. The account owner user 
+assigns these roles, either global (multiproduct) or product-specific (for example, Cloud 
+DNS), to account users.
 
 Assigning Roles to Account Users
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The account owner (identity:user-admin) can create account users on the account and then assign roles to those users. The roles grant the account users specific permissions for accessing the capabilities of the Cloud DNS service. Each account has only one account owner, and that role is assigned by default to any Rackspace Cloud account when the account is created.
+The account owner (identity:user-admin) can create account users on the account and then 
+assign roles to those users. The roles grant the account users specific permissions for 
+accessing the capabilities of the Cloud DNS service. Each account has only one account 
+owner, and that role is assigned by default to any Rackspace Cloud account when the account 
+is created.
 
-See the Cloud Identity Client Developer Guide for information about how to perform the following tasks:
+See the Cloud Identity Client Developer Guide for information about how to perform the 
+following tasks:
 
 -  :rax-devdocs:`Add user <cloud-identity/v2/developer-guide/#add-user>` 
    
@@ -21,12 +33,14 @@ See the Cloud Identity Client Developer Guide for information about how to perfo
 
 .. note::
 
-    The account owner (identity:user-admin) role cannot hold any additional roles because it already has full access to all capabilities.
+    The account owner (identity:user-admin) role cannot hold any additional roles because 
+    it already has full access to all capabilities.
 
 Roles Available for Cloud DNS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Three roles (observer, creator, and admin) can be used to access the Cloud DNS API specifically. The following table describes these roles and their permissions.
+Three roles (observer, creator, and admin) can be used to access the Cloud DNS API 
+specifically. The following table describes these roles and their permissions.
 
 **Table. Cloud DNS Product Roles and Permissions**
 
@@ -43,7 +57,9 @@ Three roles (observer, creator, and admin) can be used to access the Cloud DNS A
 |                 | access is granted.                                                |
 +-----------------+-------------------------------------------------------------------+
 
-Additionally, two multiproduct roles apply to all products. Users with multiproduct roles inherit access to future products when those products become RBAC-enabled. The following table describes these roles and their permissions.
+Additionally, two multiproduct roles apply to all products. Users with multiproduct roles 
+inherit access to future products when those products become RBAC-enabled. The following 
+table describes these roles and their permissions.
 
 **Table. Multiproduct (Global) Roles and Permissions**
 
@@ -70,20 +86,26 @@ The following scenarios show examples of how potential conflicts between user ro
 in the Control Panel are resolved:
 
 **Scenario 1:**
-Configuration : User is assigned the following roles: multiproduct **observer** and Cloud DNS **admin**
+Configuration : User is assigned the following roles: multiproduct **observer** and Cloud 
+DNS **admin**
 
 View: Appears that the user has only the multiproduct **observer** role.
 
-Permissions: The user can perform product admin functions in the Control Panel for Cloud DNS only. The user has the **observer** role for the rest of the products.
+Permissions: The user can perform product admin functions in the Control Panel for Cloud 
+DNS only. The user has the **observer** role for the rest of the products.
 
 **Scenario 2:**
-Configuration: User is assigned the following roles: multiproduct **admin** and Cloud DNS **observer**
+Configuration: User is assigned the following roles: multiproduct **admin** and Cloud DNS 
+**observer**
 
 View: Appears that the user has only the multiproduct **admin** role.
 
-Permissions: The user can perform product admin functions in the Control Panel for all of the products. The Cloud DNS **observer** role is ignored.
+Permissions: The user can perform product admin functions in the Control Panel for all of 
+the products. The Cloud DNS **observer** role is ignored.
 
 RBAC Permissions Cross-reference to Cloud DNS API Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-API operations for Cloud DNS may or may not be available to all roles. To see which operations are permitted to invoke which calls, please review `the Knowledge Center article <http://www.rackspace.com/knowledge_center/article/detailed-permissions-matrix-for-dns>`_.
+API operations for Cloud DNS may or may not be available to all roles. To see which 
+operations are permitted to invoke which calls, please review 
+:how-to:`Detailed Permissions Matrix for DNS <detailed-permissions-matrix-for-dns>`.

--- a/api-docs/v1/index.rst
+++ b/api-docs/v1/index.rst
@@ -17,8 +17,8 @@ Cloud DNS service REST API.
 The Rackspace Cloud DNS API enables developers to view and manage domains, subdomains, and
 records through a simple Representational State Transfer (REST) web service interface.
 
-For more information about the DNS service, see the `Cloud DNS FAQ <http://www.rackspace.com/knowledge_center/article/rackspace-cloud-dns-faq>`_
-in the Rackspace Knowledge Center.
+For more information about the DNS service, see the :how-to:`Cloud DNS FAQ <cloud-dns-faq>`
+in the Rackspace How To.
 
 
 .. toctree:: :hidden:

--- a/api-docs/v1/overview/additional-resources.rst
+++ b/api-docs/v1/overview/additional-resources.rst
@@ -3,14 +3,21 @@
 Additional resources
 ~~~~~~~~~~~~~~~~~~~~
 
-Issues and bug reports can be directed to your support team via ticket,
-chat, email, or phone.
+Issues and bug reports can be directed to your support team via ticket, chat, email, or phone.
 
-You can download the most current versions of other API-related documents from http://developer.rackspace.com/.
+You can download the most current versions of other API-related documents from 
+:rax-dev:`developer.rackspace.com<>`.
 
-For more details about Rackspace Cloud DNS, refer to http://www.rackspace.com/cloud/dns. This site also offers links to Rackspace's official support channels, including knowledge center articles, forums, phone, chat, and email.
+For more details about Rackspace Cloud DNS, refer to http://www.rackspace.com/cloud/dns. 
+This site also offers links to Rackspace's official support channels, including How To 
+articles, forums, phone, chat, and email.
 
-Using this API document, your Rackspace Cloud account, and at least two cloud servers, you can get started whenever you'd like. See the *Getting Started with Rackspace Cloud DNS* at http://docs.rackspace.com/ for information about getting started using the API.
+For more information about the Cloud DNS service, see the :how-to:`Cloud DNS FAQ <cloud-dns-faq>`
+in the Rackspace How To.
+
+Using this API document, your Rackspace Cloud account, and at least two cloud servers, you 
+can get started whenever you'd like. See the :rax-devdocs:`Pagination <cloud-dns/v1/developer-guide/#getting-started-guide>`.
+for information about getting started using the API.
 
 Please visit our `Product Feedback Forum`_ and let us know what you think about Cloud DNS!
 

--- a/api-docs/v2/conf.py
+++ b/api-docs/v2/conf.py
@@ -120,7 +120,6 @@ extlinks = {
     'rax-glossary': ('https://developer.rackspace.com/docs/glossary/%s', ''),
     'mycloud': ('https://mycloud.rackspace.com/%s', ''),
     'how-to': ('http://support.rackspace.com/how-to/%s', ''),
-    'h2': ('https://support.rackspace.com/how-to/%s',''),
     'os': ('http://www.openstack.org/%s', ''),
     'os-docs': ('http://docs.openstack.org/%s', ''),
     'os-wiki': ('http://wiki.openstack.org/%s', ''),

--- a/api-docs/v2/general-api-info/role-based-access-control.rst
+++ b/api-docs/v2/general-api-info/role-based-access-control.rst
@@ -115,4 +115,4 @@ RBAC permissions cross-reference to |apiservice| operations
 
 API operations for |product name| may or may not be available to all roles. To see which 
 operations are permitted to invoke which operations, see the 
-:h2:`Detailed Permissions Matrix for DNS <detailed-permissions-matrix-for-dns>` 
+:how-to:`Detailed Permissions Matrix for DNS <detailed-permissions-matrix-for-dns>` 

--- a/api-docs/v2/overview/additional-resources.rst
+++ b/api-docs/v2/overview/additional-resources.rst
@@ -6,7 +6,7 @@ Additional resources
 You can download the most current versions of other API-related documents from 
 :rax-dev:`developer.rackspace.com<>`.
 
-For more information about the |product name| service, see the :h2:`Managed DNS FAQ <managed-dns-faq>`
+For more information about the |product name| service, see the :how-to:`Managed DNS FAQ <managed-dns-faq>`
 in the Rackspace How-To. 
 
 For information about Rackspace Cloud products, see the :rax-cloud:`Rackspace Public Cloud site<>`.

--- a/api-docs/v2/overview/index.rst
+++ b/api-docs/v2/overview/index.rst
@@ -6,7 +6,7 @@ About the Rackspace Managed DNS API
 The |apiservice| enables developers to view and manage domains, subdomains, and records 
 through a simple Representational State Transfer (REST) web service interface.
 
-For more information about the |product name| service, see the :h2:`Managed DNS FAQ <managed-dns-faq>`
+For more information about the |product name| service, see the :how-to:`Managed DNS FAQ <managed-dns-faq>`
 in the Rackspace How-To. 
 
 |product name| is a globally distributed (Anycast network) service that 


### PR DESCRIPTION
make sure to reference how-to instead of kc when building links