### PR TITLE
Update v1 dns docs release notes

### DIFF
--- a/api-docs/v1/api-reference/methods/get-export-domain-v1.0-account-domains-domainid-export.rst
+++ b/api-docs/v1/api-reference/methods/get-export-domain-v1.0-account-domains-domainid-export.rst
@@ -27,11 +27,8 @@ no subdomain information is provided).
    *  The BIND 9 formatted contents of the requested domain will have no
       comments listed for the domain or for the records of the domain being
       exported.
-   *  If there are more than 300 records in the Export domain operation,
-      records are dropped from the export due to a known defect. Please contact
-      your support team to perform the export for you.
    *  The following examples show the final successful response for the
-      asynchronous call.
+      asynchronous call with showDetails set to true.
 
 
 This table shows the possible response codes for this operation:
@@ -104,7 +101,7 @@ This operation does not accept a request body.
 
 .. code::
 
-   GET https://dns.api.rackspacecloud.com/v1.0/1234/domains/2725339/export
+   GET https://dns.api.rackspacecloud.com/v1.0/hybrid:30720/domains/292786/export
    Accept: application/xml
    X-Auth-Token: ea85e6ac-baff-4a6c-bf43-848020ea3812
    Content-Type: application/xml
@@ -116,7 +113,7 @@ This operation does not accept a request body.
 
 .. code::
 
-   GET https://dns.api.rackspacecloud.com/v1.0/1234/domains/2725339/export
+   GET https://dns.api.rackspacecloud.com/v1.0/hybrid:30720/domains/292786/export
    Accept: application/json
    X-Auth-Token: ea85e6ac-baff-4a6c-bf43-848020ea3812
    Content-Type: application/json
@@ -131,24 +128,39 @@ Response
 
 .. code::
 
-   Status: 202 Accepted
-   Date: Thu, 28 Jul 2011 21:54:21 GMT
-   X-API-VERSION: 1.0.17
+   Status: 200 OK
+   Date: Fri, 29 Oct 2021 21:21:04 GMT
    Content-Type: application/xml
-   Content-Length: 665
+   Content-Length: 826
 
    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-   <domain id="2725339" accountId="1234" contentType="BIND_9" xmlns:ns2="http://www.w3.org/2005/Atom" xmlns="http://docs.rackspacecloud.com/dns/api/v1.0" xmlns:ns3="http://docs.rackspacecloud.com/dns/api/management/v1.0">
-       <contents>
-       		example.net. 3600 IN SOA ns.rackspace.com.
-   			sample@rackspace.com. 1308874739 3600 3600 3600 3600
-   			example.net. 86400 IN A 110.11.12.16
-   			example.net. 3600 IN MX 5 mail2.example.net.
-   			www.example.net. 5400 IN CNAME example.net.
-   			example.net. 5600 IN NS ns.rackspace.com.
-   			example.net. 5600 IN NS ns2.rackspace.com.
-   		</contents>
-   </domain>
+   <callbackUrl>https://dns.api.rackspacecloud.com/v1.0/hybrid:30720/status/017d0607-07b7-4000-b938-41c43289bf3b</callbackUrl>
+   <jobId>017d0607-07b7-4000-b938-41c43289bf3b</jobId>
+   <requestUrl>https://dns.api.rackspacecloud.com/v1.0/hybrid:30720/domains/292786/export</requestUrl>
+   <response>
+       <contents>;Configuration for DNS Zone example.com
+
+   ;-----;example.com;
+   example.com. 300 IN SOA ns.rackspace.com. hostmaster.rackspace.com. (
+   1628878394
+   10800
+   3600
+   604800
+   300
+   )
+   pop3.example.com. 86400 IN CNAME example.com.
+   www.example.com. 86400 IN CNAME example.com.
+   example.com. 86400 IN NS ns.rackspace.com.
+   example.com. 86400 IN NS ns2.rackspace.com.
+
+   example.com. 300 IN TXT "a blah blah blah"
+   </contents>
+       <id>292786</id>
+       <accountId>hybrid:30720</accountId>
+       <contentType>BIND_9</contentType>
+   </response>
+   <verb>GET</verb>
+   <status>COMPLETED</status>
 
 
 **Example Export domain: JSON response**
@@ -156,17 +168,23 @@ Response
 
 .. code::
 
-   Status: 202 Accepted
-   Date: Thu, 28 Jul 2011 21:54:21 GMT
-   X-API-VERSION: 1.0.17
+   Status: 200 OK
+   Date: Fri, 29 Oct 2021 21:21:04 GMT
    Content-Type: application/json
-   Content-Length: 476
+   Content-Length: 780
 
    {
-     "id" : 2725339,
-     "contentType" : "BIND_9",
-     "contents" : "\n    \t\texample.net. 3600 IN SOA ns.rackspace.com.\n\t\t\tsample@rackspace.com. 1308874739 3600 3600 3600 3600\n\t\t\texample.net. 86400 IN A 110.11.12.16\n\t\t\texample.net. 3600 IN MX 5 mail2.example.net.\n\t\t\twww.example.net. 5400 IN CNAME example.net.\n\t\t\texample.net. 5600 IN NS ns.rackspace.com.\n\t\t\texample.net. 5600 IN NS ns2.rackspace.com.\t\t\t\n\t\t",
-     "accountId" : 1234
+    "callbackUrl": "https://dns.api.rackspacecloud.com/v1.0/hybrid:30720/status/017d0607-07b7-4000-b938-41c43289bf3b",
+    "jobId": "017d0607-07b7-4000-b938-41c43289bf3b",
+    "requestUrl": "https://dns.api.rackspacecloud.com/v1.0/hybrid:30720/domains/292786/export",
+    "response": {
+        "contents": ";Configuration for DNS Zone example.com\n\n;-----;example.com;\nexample.com. 300 IN SOA ns.rackspace.com. hostmaster.rackspace.com. (\n1628878394\n10800\n3600\n604800\n300\n)\npop3.example.com. 86400 IN CNAME example.com.\nwww.example.com. 86400 IN CNAME example.com.\nexample.com. 86400 IN NS ns.rackspace.com.\nexample.com. 86400 IN NS ns2.rackspace.com.\n\nexample.com. 300 IN TXT \"a blah blah blah\"\n",
+        "id": "292786",
+        "accountId": "hybrid:30720",
+        "contentType": "BIND_9"
+    },
+    "verb": "GET",
+    "status": "COMPLETED"
    }
 
 

--- a/api-docs/v1/api-reference/methods/get-list-domain-details-without-subdomains-v1.0-account-domains-domainid.rst
+++ b/api-docs/v1/api-reference/methods/get-list-domain-details-without-subdomains-v1.0-account-domains-domainid.rst
@@ -156,7 +156,7 @@ Response
 
    {
      "name" : "example.com",
-     "id" : 2725233,
+     "id" : "2725233",
      "comment" : "Optional domain comment...",
      "updated" : "2011-06-24T01:23:15.000+0000",
      "nameservers" : [ {
@@ -164,7 +164,7 @@ Response
      }, {
        "name" : "ns2.rackspace.com"
      } ],
-     "accountId" : 1234,
+     "accountId" : "1234",
      "recordsList" : {
        "totalEntries" : 6,
        "records" : [ {

--- a/api-docs/v1/api-reference/methods/get-list-domains-by-name-v1.0-account-domains.rst
+++ b/api-docs/v1/api-reference/methods/get-list-domains-by-name-v1.0-account-domains.rst
@@ -154,7 +154,7 @@ Response
    {
      "domains" : [ {
        "name" : "region2.example.net",
-       "id" : 2725352,
+       "id" : "2725352",
        "updated" : "2011-06-23T20:21:06.000+0000",
        "created" : "2011-06-23T19:24:27.000+0000"
      } ],
@@ -192,7 +192,7 @@ Response
    {
      "domains" : [ {
        "name" : "sub1.example.com",
-       "id" : 2725257,
+       "id" : "2725257",
        "comment" : "1st sample subdomain",
        "updated" : "2011-06-23T03:09:34.000+0000",
        "emailAddress" : "sample@rackspace.com",

--- a/api-docs/v1/api-reference/methods/get-list-domains-v1.0-account-domains.rst
+++ b/api-docs/v1/api-reference/methods/get-list-domains-v1.0-account-domains.rst
@@ -157,67 +157,67 @@ Response
    {
      "domains" : [ {
        "name" : "example.com",
-       "id" : 2725233,
+       "id" : "2725233",
        "comment" : "Optional domain comment...",
        "updated" : "2011-06-24T01:23:15.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-24T01:12:51.000+0000"
      }, {
        "name" : "sub1.example.com",
-       "id" : 2725257,
+       "id" : "2725257",
        "comment" : "1st sample subdomain",
        "updated" : "2011-06-23T03:09:34.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-23T03:09:33.000+0000"
      }, {
        "name" : "sub2.example.com",
-       "id" : 2725258,
+       "id" : "2725258",
        "comment" : "1st sample subdomain",
        "updated" : "2011-06-23T03:52:55.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-23T03:52:55.000+0000"
      }, {
        "name" : "north.example.com",
-       "id" : 2725260,
+       "id" : "2725260",
        "updated" : "2011-06-23T03:53:10.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-23T03:53:09.000+0000"
      }, {
        "name" : "south.example.com",
-       "id" : 2725261,
+       "id" : "2725261",
        "comment" : "Final sample subdomain",
        "updated" : "2011-06-23T03:53:14.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-23T03:53:14.000+0000"
      }, {
        "name" : "region2.example.net",
-       "id" : 2725352,
+       "id" : "2725352",
        "updated" : "2011-06-23T20:21:06.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "created" : "2011-06-23T19:24:27.000+0000"
      }, {
        "name" : "example.org",
-       "id" : 2718984,
+       "id" : "2718984",
        "updated" : "2011-05-03T14:47:32.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "created" : "2011-05-03T14:47:30.000+0000"
      }, {
        "name" : "rackspace.example",
-       "id" : 2722346,
+       "id" : "2722346",
        "updated" : "2011-06-21T15:54:31.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "created" : "2011-06-15T19:02:07.000+0000"
      }, {
        "name" : "dnsaas.example",
-       "id" : 2722347,
+       "id" : "2722347",
        "comment" : "Sample comment",
        "updated" : "2011-06-21T15:54:31.000+0000",
-       "accountId" : 1234,
+       "accountId" : "1234",
        "created" : "2011-06-15T19:02:07.000+0000"
      } ],
      "links" : [ {

--- a/api-docs/v1/api-reference/methods/get-list-subdomains-v1.0-account-domains-domainid-subdomains.rst
+++ b/api-docs/v1/api-reference/methods/get-list-subdomains-v1.0-account-domains-domainid-subdomains.rst
@@ -135,27 +135,27 @@ Response
    {
      "domains" : [ {
        "name" : "sub1.example.com",
-       "id" : 2725257,
+       "id" : "2725257",
        "comment" : "1st sample subdomain",
        "updated" : "2011-06-23T03:09:34.000+0000",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-23T03:09:33.000+0000"
      }, {
        "name" : "sub2.example.com",
-       "id" : 2725258,
+       "id" : "2725258",
        "comment" : "1st sample subdomain",
        "updated" : "2011-06-23T03:52:55.000+0000",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-23T03:52:55.000+0000"
      }, {
        "name" : "north.example.com",
-       "id" : 2725260,
+       "id" : "2725260",
        "updated" : "2011-06-23T03:53:10.000+0000",
        "emailAddress" : "sample@rackspace.com",
        "created" : "2011-06-23T03:53:09.000+0000"
      }, {
        "name" : "south.example.com",
-       "id" : 2725261,
+       "id" : "2725261",
        "comment" : "Final sample subdomain",
        "updated" : "2011-06-23T03:53:14.000+0000",
        "emailAddress" : "sample@rackspace.com",

--- a/api-docs/v1/api-reference/methods/get-search-domains-v1.0-account-domains-search.rst
+++ b/api-docs/v1/api-reference/methods/get-search-domains-v1.0-account-domains-search.rst
@@ -143,7 +143,7 @@ Response
    {
      "domains" : [ {
        "name" : "sub1.example.com",
-       "id" : 2725257,
+       "id" : "2725257",
        "comment" : "1st sample subdomain",
        "updated" : "2011-06-23T03:09:34.000+0000",
        "emailAddress" : "sample@rackspace.com",

--- a/api-docs/v1/api-reference/methods/get-show-domain-changes-v1.0-account-domains-domainid-changes.rst
+++ b/api-docs/v1/api-reference/methods/get-show-domain-changes-v1.0-account-domains-domainid-changes.rst
@@ -169,7 +169,7 @@ Response
          "originalValue" : "Tue Sep 13 15:23:15 UTC 2011"
        } ],
        "accountId" : 1234,
-       "targetId" : 45678
+       "targetId" : "45678"
      }, {
        "domain" : "rs.example.com",
        "targetType" : "MX Record",
@@ -207,7 +207,7 @@ Response
          "newValue" : "45678",
          "originalValue" : ""
        } ],
-       "targetId" : 222222
+       "targetId" : "222222"
      }, {
        "domain" : "rs.example.com",
        "targetType" : "Domain",
@@ -222,7 +222,7 @@ Response
          "originalValue" : "Thu Jul 14 15:14:41 UTC 2011"
        } ],
        "accountId" : 1234,
-       "targetId" : 45678
+       "targetId" : "45678"
      }, {
        "domain" : "rs.example.com",
        "targetType" : "CNAME Record",
@@ -256,7 +256,7 @@ Response
          "newValue" : "45678",
          "originalValue" : ""
        } ],
-       "targetId" : 87654
+       "targetId" : "87654"
      } ]
    }
 

--- a/api-docs/v1/api-reference/methods/get-show-domain-v1.0-account-domains-domainid.rst
+++ b/api-docs/v1/api-reference/methods/get-show-domain-v1.0-account-domains-domainid.rst
@@ -213,7 +213,7 @@ Response
 
    {
      "name" : "example.com",
-     "id" : 2725233,
+     "id" : "2725233",
      "comment" : "Optional domain comment...",
      "updated" : "2011-06-24T01:23:15.000+0000",
      "nameservers" : [ {
@@ -221,7 +221,7 @@ Response
      }, {
        "name" : "ns2.rackspace.com"
      } ],
-     "accountId" : 1234,
+     "accountId" : "1234",
      "recordsList" : {
        "totalEntries" : 6,
        "records" : [ {
@@ -325,7 +325,7 @@ Response
 
    {
      "name" : "example.com",
-     "id" : 2725233,
+     "id" : "2725233",
      "comment" : "Optional domain comment...",
      "updated" : "2011-06-24T01:23:15.000+0000",
      "nameservers" : [ {
@@ -333,7 +333,7 @@ Response
      }, {
        "name" : "ns2.rackspace.com"
      } ],
-     "accountId" : 1234,
+     "accountId" : "1234",
      "recordsList" : {
        "totalEntries" : 6,
        "records" : [ {
@@ -391,27 +391,27 @@ Response
      "subdomains" : {
        "domains" : [ {
          "name" : "sub1.example.com",
-         "id" : 2725257,
+         "id" : "2725257",
          "comment" : "1st sample subdomain",
          "updated" : "2011-06-23T03:09:34.000+0000",
          "emailAddress" : "sample@rackspace.com",
          "created" : "2011-06-23T03:09:33.000+0000"
        }, {
          "name" : "sub2.example.com",
-         "id" : 2725258,
+         "id" : "2725258",
          "comment" : "1st sample subdomain",
          "updated" : "2011-06-23T03:52:55.000+0000",
          "emailAddress" : "sample@rackspace.com",
          "created" : "2011-06-23T03:52:55.000+0000"
        }, {
          "name" : "north.example.com",
-         "id" : 2725260,
+         "id" : "2725260",
          "updated" : "2011-06-23T03:53:10.000+0000",
          "emailAddress" : "sample@rackspace.com",
          "created" : "2011-06-23T03:53:09.000+0000"
        }, {
          "name" : "south.example.com",
-         "id" : 2725261,
+         "id" : "2725261",
          "comment" : "Final sample subdomain",
          "updated" : "2011-06-23T03:53:14.000+0000",
          "emailAddress" : "sample@rackspace.com",
@@ -454,7 +454,7 @@ Response
 
    {
      "name" : "example.com",
-     "id" : 2725233,
+     "id" : "2725233",
      "comment" : "Optional domain comment...",
      "updated" : "2011-06-24T01:23:15.000+0000",
      "nameservers" : [ {
@@ -462,7 +462,7 @@ Response
      }, {
        "name" : "ns2.rackspace.com"
      } ],
-     "accountId" : 1234,
+     "accountId" : "1234",
      "ttl" : 3600,
      "emailAddress" : "sample@rackspace.com",
      "created" : "2011-06-24T01:12:51.000+0000"

--- a/api-docs/v1/api-reference/methods/post-clone-domain-v1.0-account-domains-domainid-clone.rst
+++ b/api-docs/v1/api-reference/methods/post-clone-domain-v1.0-account-domains-domainid-clone.rst
@@ -325,7 +325,7 @@ The following are examples of the reference domain and the resulting cloned doma
 
    {
      "name" : "cloner.com",
-     "id" : 3586209,
+     "id" : "3586209",
      "comment" : "cloner.com is a template domain for cloning others. cloner.com has subdomains - sub1.cloner.com, sub2.cloner.com, sub3.cloner.com",
      "updated" : "2013-05-06T17:10:55.000+0000",
      "nameservers" : [ {
@@ -333,7 +333,7 @@ The following are examples of the reference domain and the resulting cloned doma
      }, {
        "name" : "ns2.rackspace.com"
      } ],
-     "accountId" : 1234,
+     "accountId" : "1234",
      "recordsList" : {
        "totalEntries" : 7,
        "records" : [ {
@@ -399,21 +399,21 @@ The following are examples of the reference domain and the resulting cloned doma
      "subdomains" : {
        "domains" : [ {
          "name" : "sub1.cloner.com",
-         "id" : 3586210,
+         "id" : "3586210",
          "comment" : "sub1.cloner.com uses rackspace.com for email domain name. Sister subdomains are sub2.cloner.com, sub3.cloner.com",
          "updated" : "2013-05-06T17:10:56.000+0000",
          "emailAddress" : "administrator@rackspace.com",
          "created" : "2013-05-06T17:10:55.000+0000"
        }, {
          "name" : "sub2.cloner.com",
-         "id" : 3586211,
+         "id" : "3586211",
          "comment" : "sub1.cloner.com uses parent domain name, cloner.com, for email domain name",
          "updated" : "2013-05-06T17:10:56.000+0000",
          "emailAddress" : "admin@cloner.com",
          "created" : "2013-05-06T17:10:56.000+0000"
        }, {
          "name" : "sub3.cloner.com",
-         "id" : 3586212,
+         "id" : "3586212",
          "comment" : "sub3.cloner.com uses it's own domain name for email domain name",
          "updated" : "2013-05-06T17:10:57.000+0000",
          "emailAddress" : "adm@sub3.cloner.com",
@@ -440,7 +440,7 @@ The following are examples of the reference domain and the resulting cloned doma
 
    {
      "name" : "clone1.com",
-     "id" : 3586213,
+     "id" : "3586213",
      "comment" : "clone1.com is a template domain for cloning others. clone1.com has subdomains - sub1.clone1.com, sub2.clone1.com, sub3.clone1.com",
      "updated" : "2013-05-06T17:17:35.000+0000",
      "nameservers" : [ {
@@ -448,7 +448,7 @@ The following are examples of the reference domain and the resulting cloned doma
      }, {
        "name" : "ns2.rackspace.com"
      } ],
-     "accountId" : 1234,
+     "accountId" : "1234",
      "recordsList" : {
        "totalEntries" : 7,
        "records" : [ {
@@ -514,21 +514,21 @@ The following are examples of the reference domain and the resulting cloned doma
      "subdomains" : {
        "domains" : [ {
          "name" : "sub1.clone1.com",
-         "id" : 3586214,
+         "id" : "3586214",
          "comment" : "sub1.clone1.com uses rackspace.com for email domain name. Sister subdomains are sub2.clone1.com, sub3.clone1.com",
          "updated" : "2013-05-06T17:17:36.000+0000",
          "emailAddress" : "administrator@rackspace.com",
          "created" : "2013-05-06T17:17:36.000+0000"
        }, {
          "name" : "sub2.clone1.com",
-         "id" : 3586215,
+         "id" : "3586215",
          "comment" : "sub1.clone1.com uses parent domain name, clone1.com, for email domain name",
          "updated" : "2013-05-06T17:17:37.000+0000",
          "emailAddress" : "admin@clone1.com",
          "created" : "2013-05-06T17:17:37.000+0000"
        }, {
          "name" : "sub3.clone1.com",
-         "id" : 3586216,
+         "id" : "3586216",
          "comment" : "sub3.clone1.com uses it's own domain name for email domain name",
          "updated" : "2013-05-06T17:17:37.000+0000",
          "emailAddress" : "adm@sub3.clone1.com",

--- a/api-docs/v1/api-reference/methods/post-import-domain-v1.0-account-domains-import.rst
+++ b/api-docs/v1/api-reference/methods/post-import-domain-v1.0-account-domains-import.rst
@@ -197,69 +197,81 @@ Response
 
 .. code::
 
-   Status: 202 Accepted
-   Date: Thu, 28 Jul 2011 21:54:21 GMT
-   X-API-VERSION: 1.0.17
+   Status: 200 OK
+   Date: Tue, 09 Nov 2021 20:28:58 GMT
    Content-Type: application/xml
    Content-Length: 855
 
    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-   <domains xmlns:ns2="http://www.w3.org/2005/Atom" xmlns="http://docs.rackspacecloud.com/dns/api/v1.0" xmlns:ns3="http://docs.rackspacecloud.com/dns/api/management/v1.0">
-       <domain name="example.net" ttl="3600" emailAddress="sample@rackspace.com" comment="Optional domain comment...">
-           <nameservers>
-               <nameserver name="ns.rackspace.com"/>
-               <nameserver name="ns2.rackspace.com"/>
-           </nameservers>
-           <recordsList totalEntries="3">
-               <record type="A" name="example.net" data="110.11.12.16" ttl="86400"/>
-               <record type="MX" name="example.net" data="mail2.example.net" ttl="3600" priority="5"/>
-               <record type="CNAME" name="www.example.net" data="example.net" ttl="5400"/>
-           </recordsList>
-       </domain>
-   </domains>
+   <callbackUrl>https://dns.api.rackspacecloud.com/v1.0/1234/status/017d0607-07b7-4000-b938-41c43289bf3b</callbackUrl>
+   <jobId>017d0607-07b7-4000-b938-41c43289bf3b</jobId>
+   <requestUrl>https://dns.api.rackspacecloud.com/v1.0/1234/domains/import</requestUrl>
+   <response>
+      <domains>
+          <domain name="example.net" ttl="3600" emailAddress="sample@rackspace.com" comment="Optional domain comment...">
+              <nameservers>
+                  <nameserver name="ns.rackspace.com"/>
+                  <nameserver name="ns2.rackspace.com"/>
+              </nameservers>
+              <recordsList totalEntries="3">
+                  <record type="A" name="example.net" data="110.11.12.16" ttl="86400"/>
+                  <record type="MX" name="example.net" data="mail2.example.net" ttl="3600" priority="5"/>
+                  <record type="CNAME" name="www.example.net" data="example.net" ttl="5400"/>
+              </recordsList>
+          </domain>
+      </domains>
+   </response>
+   <verb>POST</verb>
+   <status>COMPLETED</status>
 
 **Example Import domain: JSON response**
 
 
 .. code::
 
-   Status: 202 Accepted
-   Date: Thu, 28 Jul 2011 21:54:21 GMT
-   X-API-VERSION: 1.0.17
+   Status: 200 OK
+   Date: Tue, 09 Nov 2021 20:28:58 GMT
    Content-Type: application/json
    Content-Length: 756
 
    {
-     "domains" : [ {
-       "name" : "example.net",
-       "comment" : "Optional domain comment...",
-       "nameservers" : [ {
-         "name" : "ns.rackspace.com"
-       }, {
-         "name" : "ns2.rackspace.com"
-       } ],
-       "recordsList" : {
-         "totalEntries" : 3,
-         "records" : [ {
+     "callbackUrl": "https://dns.api.rackspacecloud.com/v1.0/1234/status/017d0607-07b7-4000-b938-41c43289bf3b",
+     "jobId": "017d0607-07b7-4000-b938-41c43289bf3b",
+     "requestUrl": "https://dns.api.rackspacecloud.com/v1.0/1234/domains/import",
+     "response": {
+         "domains" : [ {
            "name" : "example.net",
-           "type" : "A",
-           "data" : "110.11.12.16",
-           "ttl" : 86400
-         }, {
-           "name" : "example.net",
-           "priority" : 5,
-           "type" : "MX",
-           "data" : "mail2.example.net",
-           "ttl" : 3600
-         }, {
-           "name" : "www.example.net",
-           "type" : "CNAME",
-           "data" : "example.net",
-           "ttl" : 5400
+           "comment" : "Optional domain comment...",
+           "nameservers" : [ {
+             "name" : "ns.rackspace.com"
+           }, {
+             "name" : "ns2.rackspace.com"
+           } ],
+           "recordsList" : {
+             "totalEntries" : 3,
+             "records" : [ {
+               "name" : "example.net",
+               "type" : "A",
+               "data" : "110.11.12.16",
+               "ttl" : 86400
+             }, {
+               "name" : "example.net",
+               "priority" : 5,
+               "type" : "MX",
+               "data" : "mail2.example.net",
+               "ttl" : 3600
+             }, {
+               "name" : "www.example.net",
+               "type" : "CNAME",
+               "data" : "example.net",
+               "ttl" : 5400
+             } ]
+           },
+           "ttl" : 3600,
+           "emailAddress" : "sample@rackspace.com"
          } ]
-       },
-       "ttl" : 3600,
-       "emailAddress" : "sample@rackspace.com"
-     } ]
+     },
+     "verb": "POST",
+     "status": "COMPLETED"
    }
 

--- a/api-docs/v1/api-reference/methods/put-update-domains-v1.0-account-domains.rst
+++ b/api-docs/v1/api-reference/methods/put-update-domains-v1.0-account-domains.rst
@@ -134,12 +134,12 @@ This operation does not accept a request body.
 
    {
      "domains" : [ {
-       "id" : 2725233,
+       "id" : "2725233",
        "comment" : "Optional domain comment...",
        "ttl" : 3600,
        "emailAddress" : "sample@rackspace.com"
      }, {
-       "id" : 2725257,
+       "id" : "2725257",
        "comment" : "1st sample subdomain",
        "emailAddress" : "sample@rackspace.com"
      } ]

--- a/api-docs/v1/release-notes/index.rst
+++ b/api-docs/v1/release-notes/index.rst
@@ -15,6 +15,7 @@ following release note information.
 .. note:: For information about using the API, see the
    :ref:`documentation overview <index>`.
 
+.. include:: releases/cdns-v1-0-35-20210921.rst
 .. include:: releases/cdns-v1-0-34-20141024.rst
 .. include:: releases/cdns-v1-0-34-20141014.rst
 .. include:: releases/cdns-v1-0-33-20140729.rst

--- a/api-docs/v1/release-notes/releases/cdns-v1-0-35-20210921.rst
+++ b/api-docs/v1/release-notes/releases/cdns-v1-0-35-20210921.rst
@@ -14,10 +14,10 @@ The migration did change a few minor details about the contract. The following a
 
 Ids are no longer just integers
 +++++++++++++++++++++++++++++++
-As a result of the migration id data type is now of type string. There are now four possible formats.
+As a result of the migration, id and accountId data type is now of type string. There are now four possible formats.
 
 - Ids as a 32 digit UUID. This is the new v2 format for all ids. example: 94a01109-94d3-44df-ae95-5fb1d94edfd4
-- Ids as integers. Applies to migrated v1 zone Ids. example: 123456
+- Ids and accountIds as integers. Applies to migrated v1 zone Ids and all accountIds. example: 123456
 - Ids as a record type plus an integer. Applies to migrated v1 record ids. example: A-123456, TXT-123456
 - Ids as a 10 digit hexadecimal. Applies to migrated audit Ids. example: 0a1b2c3d4e
 

--- a/api-docs/v1/release-notes/releases/cdns-v1-0-35-20210921.rst
+++ b/api-docs/v1/release-notes/releases/cdns-v1-0-35-20210921.rst
@@ -1,0 +1,37 @@
+.. _cdns-v1-20210921:
+
+v1.0.35 Environment Changes, September 21, 2021
+-----------------------------------------------
+
+What's new
+~~~~~~~~~~
+
+Environment Changes
+*******************
+
+The v1 environment was migrated to the v2 environment. For the most part the v1 contract was kept the same.
+The migration did change a few minor details about the contract. The following are the changes:
+
+Ids are no longer just integers
++++++++++++++++++++++++++++++++
+As a result of the migration id data type is now of type string. There are now four possible formats.
+
+- Ids as a 32 digit UUID. This is the new v2 format for all ids. example: 94a01109-94d3-44df-ae95-5fb1d94edfd4
+- Ids as integers. Applies to migrated v1 zone Ids. example: 123456
+- Ids as a record type plus an integer. Applies to migrated v1 record ids. example: A-123456, TXT-123456
+- Ids as a 10 digit hexadecimal. Applies to migrated audit Ids. example: 0a1b2c3d4e
+
+Checking Job status
++++++++++++++++++++
+Jobs have the possibility of immediately returning a status of COMPLETED whereas previous behavior RUNNING would be returned.
+
+
+Resolved issues
+~~~~~~~~~~~~~~~
+
+|no changes|
+
+Known issues
+~~~~~~~~~~~~
+
+|no changes|


### PR DESCRIPTION
Hello Rackspace documentation team. I am a fellow Racker working on the DNS project. Just wanted to update the docs with new release notes so our public facing Customers can be aware of the new changes. Any feedback and corrections would be welcomed. Thanks.

This adds new release notes detailing the changes the occurred for the v1 to v2 dns migration. Also updates the code examples for various domain endpoints. The major change being the ids and accountIds being string values.

jira:
https://jira.rax.io/browse/DCXDNS-384

**Quality audit reminder**

Doc team: While logged in using your O365 account, complete the quality checklist at http://bit.ly/2hwvBKX. Use the checklist for significant doc changes or additions submitted by you or a non-doc staff contributor.
