### PR TITLE
Replace: polyfill

### DIFF
--- a/api-docs/v1/_templates/scripts.html
+++ b/api-docs/v1/_templates/scripts.html
@@ -121,5 +121,5 @@
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
 <script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
+    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
 </script>

--- a/api-docs/v2/_templates/scripts.html
+++ b/api-docs/v2/_templates/scripts.html
@@ -121,5 +121,5 @@
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
 <script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
+    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
 </script>


### PR DESCRIPTION
**Quality audit reminder**

Doc team: While logged in using your O365 account, complete the quality checklist at http://bit.ly/2hwvBKX. Use the checklist for significant doc changes or additions submitted by you or a non-doc staff contributor.


@the2hill 
Github url: https://developer.rackspace.com/docs/cloud-dns/v1/developer-guide/ maps to Readme.io URL: https://docs.rackspace.com/reference/cloud-dns-developer-guide as "page has been moved"
Could you please confirm about the migration of the repo in GitHub and if migrated the please merge the PR.

There are two folders showing V1 and V2, in both folders **polyfill.io -> polyfill-fastly.io** is updated
  
